### PR TITLE
Concatenate items added via multiple calls to precache()

### DIFF
--- a/lib/shed.js
+++ b/lib/shed.js
@@ -152,7 +152,7 @@ function precache(items) {
   if (!Array.isArray(items)) {
     items = [items];
   }
-  options.preCacheItems = items;
+  options.preCacheItems = options.preCacheItems.concat(items);
 }
 
 module.exports = {


### PR DESCRIPTION
I've come across situations in which I want to call `shed.precache()` multiple times from different scripts, and currently that will cause the precache list to be overwritten each time. Instead, the change in this PR will concatenate to the existing list each time it's called.

(I am not sure where all those changes to `dist/shed.js` came from—perhaps I built it with a more recent version of some of the npm dependencies? Do those look okay to you, @wibblymat?)